### PR TITLE
Swappable secret-sharing algorithms

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 /// An error during proving or verification, such as a verification failure.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum ProofError {
     /// Something is wrong with the proof, causing a verification failure.
     #[error("Verification failed.")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub extern crate rand;
 
 pub use merlin::Transcript;
 
-mod errors;
+pub mod errors;
 mod proofs;
 mod util;
 

--- a/src/toolbox/mod.rs
+++ b/src/toolbox/mod.rs
@@ -248,3 +248,9 @@ impl TranscriptProtocol for Transcript {
         Scalar::from_bytes_mod_order_wide(&bytes)
     }
 }
+
+pub enum ProofType {
+    Unknown,
+    Xor,
+    Shamir,
+}

--- a/src/toolbox/mod.rs
+++ b/src/toolbox/mod.rs
@@ -44,6 +44,9 @@ pub mod verifier;
 pub mod shamir;
 /// generic secret sharing trait
 pub mod secrets;
+/// Implements secret sharing via XOR
+pub mod xor;
+
 pub mod util;
 
 

--- a/src/toolbox/prover.rs
+++ b/src/toolbox/prover.rs
@@ -386,7 +386,6 @@ impl<'a> IsSigmaProtocol for Prover<'a> {
     }
 
     fn challenge(&mut self) {
-        // trace!("Prover's transcript is {:?}", self.transcript);
         self.challenge = self.transcript.get_challenge(b"chal");
         trace!("Prover's transcript challenge is {:?}", self.challenge);
     }
@@ -396,15 +395,7 @@ impl<'a> IsSigmaProtocol for Prover<'a> {
         let fake_responses = &self.fake_responses;
         let responses: Vec<Scalar>;
 
-        // Construct a TranscriptRng
-        let mut rng_builder = self.transcript.build_rng();
-        for scalar in &self.scalars {
-            if scalar.is_some() {
-                rng_builder = rng_builder.rekey_with_witness_bytes(b"", scalar.unwrap().as_bytes());
-            }
-        }
-        let mut rng = rng_builder.finalize(&mut thread_rng());
-        // let mut rng = rand::thread_rng();
+        let mut rng = rand::thread_rng();
         let challenges: Vec<Scalar>;
 
         match self.proof_type {

--- a/src/toolbox/prover.rs
+++ b/src/toolbox/prover.rs
@@ -9,6 +9,7 @@ use crate::{BatchableProof, CompactProof, Transcript, ProofError};
 use crate::toolbox::shamir::Shamir;
 use crate::toolbox::xor::Xor;
 use crate::toolbox::secrets::SecretSharing;
+use crate::toolbox::util::random_scalar;
 use std::iter;
 use std::str;
 use log::{trace, debug};
@@ -320,7 +321,7 @@ impl<'a> IsSigmaProtocol for Prover<'a> {
                                 shares.push(None);
                             } else {
                                 // this is a faked clause, so we need to randomize a challenge for it
-                                shares.push(Some(Scalar::random(&mut transcript_rng)));
+                                shares.push(Some(random_scalar(&mut transcript_rng)));
                             };
                         },
                         None => (),

--- a/src/toolbox/prover.rs
+++ b/src/toolbox/prover.rs
@@ -4,9 +4,10 @@ use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::traits::MultiscalarMul;
 
-use crate::toolbox::{SchnorrCS, TranscriptProtocol, IsSigmaProtocol};
+use crate::toolbox::{SchnorrCS, TranscriptProtocol, IsSigmaProtocol, ProofType};
 use crate::{BatchableProof, CompactProof, Transcript, ProofError};
 use crate::toolbox::shamir::Shamir;
+use crate::toolbox::xor::Xor;
 use crate::toolbox::secrets::SecretSharing;
 use std::iter;
 use std::str;
@@ -42,6 +43,7 @@ pub struct Prover<'a> {
     known_chal_shares: Vec<Option<Scalar>>,
     nr_clauses: usize,
     challenge: Scalar,
+    proof_type: ProofType,
 }
 
 /// A secret variable used during proving.
@@ -70,7 +72,8 @@ impl<'a> Prover<'a> {
             fake_responses: Vec::default(),
             known_chal_shares: Vec::default(),
             nr_clauses: 0,
-            challenge: Default::default()
+            challenge: Default::default(),
+            proof_type: ProofType::Unknown,
         }
     }
 
@@ -105,6 +108,10 @@ impl<'a> Prover<'a> {
             None => 0,
             Some(x) => x.0,
         };
+
+        // TODO decide which type of secret sharing we're going to use
+        self.proof_type = ProofType::Xor;
+
         let result = self.commit();
         if result.is_err() {
             return Err(result.err().unwrap());
@@ -172,90 +179,204 @@ impl<'a> IsSigmaProtocol for Prover<'a> {
         let mut fake_responses = Vec::with_capacity(self.constraints.iter().map(|cs| &cs.1).count());
         let mut shares = Vec::with_capacity(self.constraints.len());
         let mut clause_tracker = vec![None; self.nr_clauses+1];
-        // let mut prev_clause_nr = 0;
-        for (clause_nr, lhs_var, rhs_lin_combo) in &self.constraints {
-            debug!("Constraint clause {}: {} = {}",
-                clause_nr,
-                str::from_utf8(self.point_labels[lhs_var.0]).unwrap(),
-                rhs_lin_combo.iter().map(
-                    |(scal, pt)| format!("{} ^ {:?}", str::from_utf8(self.point_labels[pt.0]).unwrap(), scal.0)
-                ).collect::<Vec<String>>().join(" * ")
-            );
 
-            // The first [0] picks the first entry in the linear combination.  We can test against only this one because we
-            // know that all entries in a compound && clause (represented by a single constraint) MUST either be all known, or
-            // all unknown.  Though, we should have a way of checking this in the code before execution reaches this point.
-            // The second .0 pulls out the ScalarVar which the PointVar is to be raised to.  The third .0 selects the single entry
-            // of the ScalarVar tuple, which is a usize representing the index of the ScalarVar's value in self.scalars and self.blindings.
-            let sv_index = (rhs_lin_combo[0].0).0;
-            let commitment = match blindings[sv_index].is_some() {
-                true => {               // if we have a blinding, that means we have a secret value for this variable
-                    clause_tracker[*clause_nr] = match clause_tracker[*clause_nr] {
-                        // this is the first time we've worked with this clause, initialize the tracker
-                        None => Some((1, 1)),
-
-                        // We're adding a new known value, so increment the tracker
-                        Some((terms, filled_in)) => Some((terms+1, filled_in+1)),
+        match self.proof_type {
+            ProofType::Shamir => {
+                for (clause_nr, lhs_var, rhs_lin_combo) in &self.constraints {
+                    debug!("Constraint clause {}: {} = {}",
+                        clause_nr,
+                        str::from_utf8(self.point_labels[lhs_var.0]).unwrap(),
+                        rhs_lin_combo.iter().map(
+                            |(scal, pt)| format!("{} ^ {:?}", str::from_utf8(self.point_labels[pt.0]).unwrap(), scal.0)
+                        ).collect::<Vec<String>>().join(" * ")
+                    );
+        
+                    // The first [0] picks the first entry in the linear combination.  We can test against only this one because we
+                    // know that all entries in a compound && clause (represented by a single constraint) MUST either be all known, or
+                    // all unknown.  Though, we should have a way of checking this in the code before execution reaches this point.
+                    // The second .0 pulls out the ScalarVar which the PointVar is to be raised to.  The third .0 selects the single entry
+                    // of the ScalarVar tuple, which is a usize representing the index of the ScalarVar's value in self.scalars and self.blindings.
+                    let sv_index = (rhs_lin_combo[0].0).0;
+                    let commitment = match blindings[sv_index].is_some() {
+                        true => {               // if we have a blinding, that means we have a secret value for this variable
+                            clause_tracker[*clause_nr] = match clause_tracker[*clause_nr] {
+                                // this is the first time we've worked with this clause, initialize the tracker
+                                None => Some((1, 1)),
+        
+                                // We're adding a new known value, so increment the tracker
+                                Some((terms, filled_in)) => Some((terms+1, filled_in+1)),
+                            };
+        
+                            shares.push(None);
+                            RistrettoPoint::multiscalar_mul(
+                                rhs_lin_combo.iter().map(|(sc_var, _pt_var)| {
+                                    fake_responses.push(None);
+                                    blindings[sc_var.0].unwrap()
+                                }),
+                                rhs_lin_combo.iter().map(|(_sc_var, pt_var)| {
+                                    self.points[pt_var.0]
+                                }),
+                            )
+                        }
+                        false => {              // if we don't have a blinding, we don't have a secret value and will be faking one
+                            clause_tracker[*clause_nr] = match clause_tracker[*clause_nr] {
+                                // this is the first time we've worked with this clause, initialize the tracker
+                                None => Some((1, 0)),
+        
+                                // we've added no new information here, so just count a new clause
+                                Some((terms, filled_in)) => Some((terms+1, filled_in)),
+                            };
+        
+                            let challenge = Scalar::random(&mut transcript_rng);
+                            shares.push(Some(challenge));
+                            RistrettoPoint::multiscalar_mul(
+                                rhs_lin_combo.iter()
+                                    .map(|(_sc_var, _pt_var)| {
+                                        let response = Scalar::random(&mut transcript_rng);
+                                        fake_responses.push(Some(response));
+                                        response
+                                    })
+                                    .chain(iter::once(-&challenge)),
+                                rhs_lin_combo.iter()
+                                    .map(|(_sc_var, pt_var)| self.points[pt_var.0])
+                                    .chain(iter::once(self.points[lhs_var.0])),
+                            )
+                        }
                     };
+        
+                    let encoding = self
+                        .transcript
+                        .append_blinding_commitment(self.point_labels[lhs_var.0], &commitment);
 
-                    shares.push(None);
-                    RistrettoPoint::multiscalar_mul(
-                        rhs_lin_combo.iter().map(|(sc_var, _pt_var)| {
-                            fake_responses.push(None);
-                            blindings[sc_var.0].unwrap()
-                        }),
-                        rhs_lin_combo.iter().map(|(_sc_var, pt_var)| {
-                            self.points[pt_var.0]
-                        }),
-                    )
+                    trace!("Appending blinding {:?}", encoding);
+        
+                    commitments.push(encoding);
                 }
-                false => {              // if we don't have a blinding, we don't have a secret value and will be faking one
-                    clause_tracker[*clause_nr] = match clause_tracker[*clause_nr] {
-                        // this is the first time we've worked with this clause, initialize the tracker
-                        None => Some((1, 0)),
+                // Now that we know all the clauses, make sure at least one is full
+                let mut have_one = false;
+                for (i, clause) in clause_tracker.iter().enumerate() {
+                    match clause {
+                        Some((terms, filled_in)) => {
+                            debug!("Clause {} has {} terms and we know {} keys", i, terms, filled_in);
+                            if terms == filled_in { have_one = true; break; }
+                        },
+                        None => (),
+                    }
+                }
+                if !have_one {
+                    return Err(ProofError::InsufficientKeys)
+                }
+            },
+            ProofType::Xor => {
+                // General approach: we're going to have C clauses, each of which will have D constraints, each of which might have E terms
+                // We've already generated a blinding for each possible E term
+                // We need to track the D constraints so we can calculate completeness of each C
+                // We should only have one fully-complete C, for which the c_i value can be calculated
+                // For all other Cs except 1, we can randomize the c_i value
 
-                        // we've added no new information here, so just count a new clause
-                        Some((terms, filled_in)) => Some((terms+1, filled_in)),
+                // do ClauseTracker logic first, so we can trigger on it later on
+                for (clause_nr, lhs_var, rhs_lin_combo) in &self.constraints {
+                    debug!("Constraint clause {}: {} = {}",
+                        clause_nr,
+                        str::from_utf8(self.point_labels[lhs_var.0]).unwrap(),
+                        rhs_lin_combo.iter().map(
+                            |(scal, pt)| format!("{} ^ {:?}", str::from_utf8(self.point_labels[pt.0]).unwrap(), scal.0)
+                        ).collect::<Vec<String>>().join(" * ")
+                    );
+
+                    let sv_index = (rhs_lin_combo[0].0).0;
+                    match blindings[sv_index].is_some() {
+                        true => {               // if we have a blinding, that means we have a secret value for this variable
+                            clause_tracker[*clause_nr] = match clause_tracker[*clause_nr] {
+                                // this is the first time we've worked with this clause, initialize the tracker
+                                None => Some((1, 1)),
+        
+                                // We're adding a new known value, so increment the tracker
+                                Some((terms, filled_in)) => Some((terms+1, filled_in+1)),
+                            };
+                        },
+                        false => {
+                            clause_tracker[*clause_nr] = match clause_tracker[*clause_nr] {
+                                // this is the first time we've worked with this clause, initialize the tracker
+                                None => Some((1, 0)),
+        
+                                // we've added no new information here, so just count a new clause
+                                Some((terms, filled_in)) => Some((terms+1, filled_in)),
+                            };
+                        }
                     };
+                };
 
-                    let challenge = Scalar::random(&mut transcript_rng);
-                    shares.push(Some(challenge));
-                    RistrettoPoint::multiscalar_mul(
-                        rhs_lin_combo.iter()
-                            .map(|(_sc_var, _pt_var)| {
-                                let response = Scalar::random(&mut transcript_rng);
-                                fake_responses.push(Some(response));
-                                response
-                            })
-                            .chain(iter::once(-&challenge)),
-                        rhs_lin_combo.iter()
-                            .map(|(_sc_var, pt_var)| self.points[pt_var.0])
-                            .chain(iter::once(self.points[lhs_var.0])),
-                    )
+                // Now that we know all the clauses, make sure at least one is full, and generate one challenge share
+                // per clause (NOT per constraint!)
+                let mut have_one = false;
+                for (i, clause) in clause_tracker.iter().enumerate() {
+                    match clause {
+                        Some((terms, filled_in)) => {
+                            debug!("Clause {} has {} terms and we know {} keys", i, terms, filled_in);
+                            if terms == filled_in {
+                                // this is a fully-known clause, so we'll be able to calculate the challenge later on
+                                have_one = true;
+                                shares.push(None);
+                            } else {
+                                // this is a faked clause, so we need to randomize a challenge for it
+                                shares.push(Some(Scalar::random(&mut transcript_rng)));
+                            };
+                        },
+                        None => (),
+                    }
                 }
-            };
+                if !have_one {
+                    return Err(ProofError::InsufficientKeys)
+                }
 
-            let encoding = self
-                .transcript
-                .append_blinding_commitment(self.point_labels[lhs_var.0], &commitment);
-
-            commitments.push(encoding);
-        }
-
-        // Now that we know all the clauses, make sure at least one is full
-        let mut have_one = false;
-        for (i, clause) in clause_tracker.iter().enumerate() {
-            match clause {
-                Some((terms, filled_in)) => {
-                    debug!("Clause {} has {} terms and we know {} keys", i, terms, filled_in);
-                    if terms == filled_in { have_one = true; break; }
-                },
-                None => (),
+                // Using the shares, calculate our commitments
+                for (clause_nr, lhs_var, rhs_lin_combo) in &self.constraints {
+                    let sv_index = (rhs_lin_combo[0].0).0;
+                    let commitment = match blindings[sv_index].is_some() {
+                        true => {               // if we have a blinding, that means we have a secret value for this variable        
+                            RistrettoPoint::multiscalar_mul(
+                                rhs_lin_combo.iter().map(|(sc_var, _pt_var)| {
+                                    fake_responses.push(None);
+                                    blindings[sc_var.0].unwrap()
+                                }),
+                                rhs_lin_combo.iter().map(|(_sc_var, pt_var)| {
+                                    self.points[pt_var.0]
+                                }),
+                            )
+                        }
+                        false => {              // if we don't have a blinding, we don't have a secret value and will be faking one        
+                            let challenge = shares[*clause_nr - 1].unwrap();
+                            RistrettoPoint::multiscalar_mul(
+                                rhs_lin_combo.iter()
+                                    .map(|(_sc_var, _pt_var)| {
+                                        let response = Scalar::random(&mut transcript_rng);
+                                        fake_responses.push(Some(response));
+                                        response
+                                    })
+                                    .chain(iter::once(-&challenge)),
+                                rhs_lin_combo.iter()
+                                    .map(|(_sc_var, pt_var)| self.points[pt_var.0])
+                                    .chain(iter::once(self.points[lhs_var.0])),
+                            )
+                        }
+                    };
+        
+                    let encoding = self
+                        .transcript
+                        .append_blinding_commitment(self.point_labels[lhs_var.0], &commitment);
+                    
+                    trace!("Appending blinding {:?}", encoding);
+        
+                    commitments.push(encoding);
+                }
+            },
+            _ => {
+                panic!("This isn't implemented yet!");
             }
         }
-        if !have_one {
-            return Err(ProofError::InsufficientKeys)
-        }
+
+        debug!("Prover generated shares {:?}", shares);
         
         self.blindings = blindings;
         self.commitments = commitments;
@@ -265,36 +386,66 @@ impl<'a> IsSigmaProtocol for Prover<'a> {
     }
 
     fn challenge(&mut self) {
+        // trace!("Prover's transcript is {:?}", self.transcript);
         self.challenge = self.transcript.get_challenge(b"chal");
+        trace!("Prover's transcript challenge is {:?}", self.challenge);
     }
 
     fn response(&mut self) {
-        // Construct a TranscriptRng
-        // let mut rng_builder = self.transcript.build_rng();
-        // for scalar in &self.scalars {
-        //     if scalar.is_some() {
-        //         rng_builder = rng_builder.rekey_with_witness_bytes(b"", scalar.unwrap().as_bytes());
-        //     }
-        // }
-        // let mut transcript_rng = rng_builder.finalize(&mut thread_rng());
-        let mut rng = rand::thread_rng();
-
-        // threshold is the number of fake_responses which are Some(), plus one to account for the secret itself
-        let threshold = 1 + self.known_chal_shares.iter().filter(|r| r.is_some()).count();
-        let mut sham = Shamir::new(threshold, &mut rng);
-        let challenges = sham.complete(&self.challenge, &self.known_chal_shares).unwrap();
         let blindings = &self.blindings;
         let fake_responses = &self.fake_responses;
-        let responses = self.scalars.iter().zip(blindings)
-            .zip(fake_responses)
-            .zip(&challenges)
-            .map(| (((scalar, blinding), fake_response), challenge) | {
-                match fake_response.is_some() {
-                    true => fake_response.unwrap(),
-                    false => scalar.unwrap() * challenge + blinding.unwrap(),
-                }
-            })
-            .collect::<Vec<Scalar>>();
+        let responses: Vec<Scalar>;
+
+        // Construct a TranscriptRng
+        let mut rng_builder = self.transcript.build_rng();
+        for scalar in &self.scalars {
+            if scalar.is_some() {
+                rng_builder = rng_builder.rekey_with_witness_bytes(b"", scalar.unwrap().as_bytes());
+            }
+        }
+        let mut rng = rng_builder.finalize(&mut thread_rng());
+        // let mut rng = rand::thread_rng();
+        let challenges: Vec<Scalar>;
+
+        match self.proof_type {
+            ProofType::Xor => {
+                let mut xor = Xor::new(&mut rng);
+                let unique_challenges = xor.complete(&self.challenge, &self.known_chal_shares).unwrap();
+                trace!("Unique challenges: {:?}", unique_challenges);
+                challenges = self.constraints.iter().map(|(clause_nr, _, _)| {
+                    unique_challenges[*clause_nr - 1]
+                }).collect();
+
+                responses = self.scalars.iter().zip(blindings)
+                    .zip(fake_responses)
+                    .zip(&challenges)
+                    .map(| (((scalar, blinding), fake_response), challenge) | {
+                        match fake_response.is_some() {
+                            true => fake_response.unwrap(),
+                            false => scalar.unwrap() * challenge + blinding.unwrap(),
+                        }
+                    })
+                    .collect::<Vec<Scalar>>();
+            },
+            ProofType::Shamir => {
+                let threshold = 1 + self.known_chal_shares.iter().filter(|r| r.is_some()).count();
+                let mut sham = Shamir::new(threshold, &mut rng);
+                challenges = sham.complete(&self.challenge, &self.known_chal_shares).unwrap();
+                responses = self.scalars.iter().zip(blindings)
+                    .zip(fake_responses)
+                    .zip(&challenges)
+                    .map(| (((scalar, blinding), fake_response), challenge) | {
+                        match fake_response.is_some() {
+                            true => fake_response.unwrap(),
+                            false => scalar.unwrap() * challenge + blinding.unwrap(),
+                        }
+                    })
+                    .collect::<Vec<Scalar>>();
+            },
+            _ => {
+                panic!("This isn't implemented yet!");
+            }
+        };
 
         let out_shares = challenges;
         let commitments = self.commitments.clone();

--- a/src/toolbox/prover.rs
+++ b/src/toolbox/prover.rs
@@ -291,12 +291,12 @@ impl<'a> IsSigmaProtocol for Prover<'a> {
             .map(| (((scalar, blinding), fake_response), challenge) | {
                 match fake_response.is_some() {
                     true => fake_response.unwrap(),
-                    false => scalar.unwrap() * challenge.unwrap() + blinding.unwrap(),
+                    false => scalar.unwrap() * challenge + blinding.unwrap(),
                 }
             })
             .collect::<Vec<Scalar>>();
 
-        let out_shares = challenges.iter().map(|s| s.unwrap()).collect();
+        let out_shares = challenges;
         let commitments = self.commitments.clone();
         self.proof = BatchableProof{
             challenges: out_shares,

--- a/src/toolbox/secrets.rs
+++ b/src/toolbox/secrets.rs
@@ -1,7 +1,17 @@
 use curve25519_dalek::scalar::Scalar;
 
+/// SecretSharing is a generic interface for implementations of secret-sharing algorithms.  For more information on secret sharing, 
+/// see the Handbook of Applied Cryptography, Section 12.7 (http://cacr.uwaterloo.ca/hac/about/chap12.pdf)
 pub trait SecretSharing {
-    fn share(&mut self, secret: &Scalar, nr_of_shares: usize) -> Vec<Option<Scalar>>;
+    /// Given a secret and the desired number of shares to calculate, create secret shares.  It should be possible to feed the output of this
+    /// function immediate back to reconstruct and obtain the same secret value.
+    fn share(&mut self, secret: &Scalar, nr_of_shares: usize) -> Result<Vec<Option<Scalar>>, String>;
+
+    /// Given a secret and a partial list of shares, calculate additional shares such that the complete list of shares will reconstruct to
+    /// the provided secret.  Note that this function does NOT provide any ordering guarantees!  Specifically, any shares you provide
+    /// the function may show up in a different place in the resulting Vector, as the algorithm needs.
     fn complete(&mut self, secret: &Scalar, shares: &Vec<Option<Scalar>>) -> Result<Vec<Option<Scalar>>, String>;
+
+    /// Given a sufficient set of shares, return the original secret value.
     fn reconstruct(&mut self, shares: &Vec<Option<Scalar>>) -> Result<Scalar, String>;
 }

--- a/src/toolbox/secrets.rs
+++ b/src/toolbox/secrets.rs
@@ -1,15 +1,17 @@
 use curve25519_dalek::scalar::Scalar;
 
-/// SecretSharing is a generic interface for implementations of secret-sharing algorithms.  For more information on secret sharing, 
-/// see the Handbook of Applied Cryptography, Section 12.7 (http://cacr.uwaterloo.ca/hac/about/chap12.pdf)
+/// SecretSharing is a generic interface for implementations of secret-sharing algorithms.  For more information on 
+/// secret sharing, see the Handbook of Applied Cryptography, Sec 12.7 (http://cacr.uwaterloo.ca/hac/about/chap12.pdf)
 pub trait SecretSharing {
-    /// Given a secret and the desired number of shares to calculate, create secret shares.  It should be possible to feed the output of this
-    /// function immediate back to reconstruct and obtain the same secret value.
+    /// Given a secret and the desired number of shares to calculate, create secret shares.  It should be possible to
+    /// feed the output of this function immediate back to reconstruct() and obtain the same secret value.
     fn share(&mut self, secret: &Scalar, nr_of_shares: usize) -> Result<Vec<Scalar>, String>;
 
-    /// Given a secret and a partial list of shares, calculate additional shares such that the complete list of shares will reconstruct to
-    /// the provided secret.  Note that this function does NOT provide any ordering guarantees!  Specifically, any shares you provide
-    /// the function may show up in a different place in the resulting Vector, as the algorithm needs.
+    /// Given a secret and a partial list of shares, calculate additional shares such that the complete list of shares
+    /// will reconstruct to the provided secret.
+    /// 
+    /// IMPLEMENTORS BEWARE: your function must not alter the ordering of shares!  That is, it should only fill in the
+    /// Nones, ensuring that all provided shares show up at the same indices in the resulting Vector.
     fn complete(&mut self, secret: &Scalar, shares: &Vec<Option<Scalar>>) -> Result<Vec<Scalar>, String>;
 
     /// Given a sufficient set of shares, return the original secret value.

--- a/src/toolbox/secrets.rs
+++ b/src/toolbox/secrets.rs
@@ -5,13 +5,13 @@ use curve25519_dalek::scalar::Scalar;
 pub trait SecretSharing {
     /// Given a secret and the desired number of shares to calculate, create secret shares.  It should be possible to feed the output of this
     /// function immediate back to reconstruct and obtain the same secret value.
-    fn share(&mut self, secret: &Scalar, nr_of_shares: usize) -> Result<Vec<Option<Scalar>>, String>;
+    fn share(&mut self, secret: &Scalar, nr_of_shares: usize) -> Result<Vec<Scalar>, String>;
 
     /// Given a secret and a partial list of shares, calculate additional shares such that the complete list of shares will reconstruct to
     /// the provided secret.  Note that this function does NOT provide any ordering guarantees!  Specifically, any shares you provide
     /// the function may show up in a different place in the resulting Vector, as the algorithm needs.
-    fn complete(&mut self, secret: &Scalar, shares: &Vec<Option<Scalar>>) -> Result<Vec<Option<Scalar>>, String>;
+    fn complete(&mut self, secret: &Scalar, shares: &Vec<Option<Scalar>>) -> Result<Vec<Scalar>, String>;
 
     /// Given a sufficient set of shares, return the original secret value.
-    fn reconstruct(&mut self, shares: &Vec<Option<Scalar>>) -> Result<Scalar, String>;
+    fn reconstruct(&mut self, shares: &Vec<Scalar>) -> Result<Scalar, String>;
 }

--- a/src/toolbox/shamir.rs
+++ b/src/toolbox/shamir.rs
@@ -133,7 +133,7 @@ impl<R> secrets::SecretSharing for Shamir<R> where R: RngCore + CryptoRng {
         return Ok(shares);
     }
 
-    /// GNote that the new shares have NO GUARANTEE of being derived from the same polynomial as the provided ones.  
+    /// Note that the new shares have NO GUARANTEE of being derived from the same polynomial as the provided ones.  
     /// We pick an all-new polynomial which fits the provided points.
     ///
     /// The sparse_shares vector should follow the "index + 1 = x" convention, but is allowed to contain None values

--- a/src/toolbox/util.rs
+++ b/src/toolbox/util.rs
@@ -1,5 +1,6 @@
 use curve25519_dalek::scalar::Scalar;
 use std::cmp::Ordering;
+use rand::{CryptoRng, RngCore};
 
 /// Raise a Scalar to an arbitrary power.  This code is SUPER dumb: not efficient and not constant-time.
 pub fn pow(x: &Scalar, p: usize) -> Scalar {
@@ -26,6 +27,22 @@ pub fn compare_scalars(a: &Scalar, b: &Scalar) -> Ordering {
         }
     }
     return Ordering::Equal;
+}
+
+/// Get a Scalar distributed randomly across the possible values WITHOUT the highest bit of \ell being set.  That is,
+/// whatever the highest 1-bit of \ell is, we ensure that every Scalar we hand back has that bit set to 0.  This 
+/// ensures the values from this function, whenever XOR'd, will never go above \ell.
+pub fn random_scalar<T>(rng: &mut T) -> Scalar
+where
+    T: RngCore + CryptoRng
+{
+    // each Scalar is 32 bytes
+    let mut bytes = [0 as u8; 32];
+    rng.fill_bytes(&mut bytes);
+
+    // only the lower 4 bits of the final byte are significant, since we ignore the 5th
+    bytes[31] &= 0x0f;
+    Scalar::from_bits(bytes)
 }
 
 #[allow(unused_imports)]

--- a/src/toolbox/verifier.rs
+++ b/src/toolbox/verifier.rs
@@ -118,12 +118,12 @@ impl<'a> Verifier<'a> {
         // Recompute the challenge and check if it's the claimed one
         let challenge = self.transcript.get_challenge(b"chal");
 
-        let shares = proof.challenges.clone().iter().map(|c| Some(*c)).collect();
+        // let shares = proof.challenges.clone();
 
         // threshold is the number of public keys NOT in the known signature group, plus at least one in the known signature group
         let threshold = (self.constraints.len() - 1) * self.constraints[0].1.len() + 1;
         let mut sham = Shamir::new_without_rng(threshold);
-        let rec_challenge = sham.reconstruct(&shares);
+        let rec_challenge = sham.reconstruct(&proof.challenges);
 
         if rec_challenge.is_ok() && challenge == rec_challenge.unwrap() {
             Ok(())
@@ -154,12 +154,12 @@ impl<'a> Verifier<'a> {
 
         let challenge = self.transcript.get_challenge(b"chal");
 
-        let shares = proof.challenges.clone().iter().map(|c| Some(*c)).collect();
+        // let shares = proof.challenges.clone();
 
         // threshold is the number of public keys NOT in the known signature group, plus at least one in the known signature group
         let threshold = (self.constraints.len() - 1) * self.constraints[0].1.len() + 1;
         let mut sham = Shamir::new_without_rng(threshold);
-        let rec_challenge = sham.reconstruct(&shares);
+        let rec_challenge = sham.reconstruct(&proof.challenges);
 
         if rec_challenge.is_ok() && challenge != rec_challenge.unwrap() {
             return Err(ProofError::VerificationFailure);

--- a/src/toolbox/verifier.rs
+++ b/src/toolbox/verifier.rs
@@ -37,7 +37,6 @@ pub struct Verifier<'a> {
     point_labels: Vec<&'static [u8]>,
     constraints: Vec<(usize, PointVar, Vec<(ScalarVar, PointVar)>)>,
     subroutines: Vec<Verifier<'a>>,
-    // proof_type: ProofType,
 }
 
 /// A secret variable used during verification.
@@ -62,7 +61,6 @@ impl<'a> Verifier<'a> {
             point_labels: Vec::default(),
             constraints: Vec::default(),
             subroutines: Vec::default(),
-            // proof_type: ProofType::Unknown,
         }
     }
 

--- a/src/toolbox/xor.rs
+++ b/src/toolbox/xor.rs
@@ -38,10 +38,8 @@ impl<R> secrets::SecretSharing for Xor<R> where R: RngCore + CryptoRng {
         }
 
         // calculate the final share as a function of the random shares and the secret
-        match xor_many_scalars(secret, &shares) {
-            Ok(val) => shares.push(val),
-            Err(e) => return Err(e),
-        }
+        let val = xor_many_scalars(secret, shares.iter());
+        shares.push(val);
 
         return Ok(shares);
     }
@@ -49,8 +47,8 @@ impl<R> secrets::SecretSharing for Xor<R> where R: RngCore + CryptoRng {
     /// For Xor, sparse_shares should include a None value for each share you want us to generate
     fn complete(&mut self, secret: &Scalar, sparse_shares: &Vec<Option<Scalar>>) -> Result<Vec<Scalar>, String> {
         let mut empties = 0;
-        let mut shares = Vec::new();
-        let mut new_shares = Vec::new();
+        let mut shares: Vec<Scalar> = Vec::new();
+        let mut new_shares: Vec<Scalar> = Vec::new();
         for share in sparse_shares.iter() {
             if share.is_some() {
                 shares.push(share.unwrap());
@@ -69,13 +67,11 @@ impl<R> secrets::SecretSharing for Xor<R> where R: RngCore + CryptoRng {
 
         info!("Completing {} empties with {} known and secret = {:?}", empties, shares.len(), secret);
 
-        match xor_many_more_scalars(secret, &shares, &new_shares) {
-            Ok(val) => {
-                debug!("The XOR'd share is {:?}", val);
-                new_shares.push(val);
-            },
-            Err(e) => return Err(e),
-        }
+        let intermediate = xor_many_scalars(secret, shares.iter());
+        let val = xor_many_scalars(&intermediate, new_shares.iter());
+
+        debug!("The XOR'd share is {:?}", val);
+        new_shares.push(val);
 
         let ret_shares: Vec<Scalar> = sparse_shares.iter().map(|x| {
             if x.is_some() {
@@ -94,105 +90,67 @@ impl<R> secrets::SecretSharing for Xor<R> where R: RngCore + CryptoRng {
             return Err(String::from("No shares provided, impossible to reconstruct!"));
         }
 
-        let secret = xor_many_scalars(&shares[0], &shares[1..]);
-        
-        debug!("Used {} shares to reconstruct {:?}", shares.len(), secret);
-        return secret;
-    }
-}
+        let secret = xor_many_scalars(&Scalar::zero(), shares.iter());
 
-/// Given two Scalar values, return the XOR of their constituent byte arrays
-pub fn xor_scalars(a: &Scalar, b: &Scalar) -> Scalar {
-    let mut the_bytes = [0 as u8; 32];
-    let abytes = a.to_bytes();
-    let bbytes = b.to_bytes();
-    for i in 0..the_bytes.len() {
-        the_bytes[i] = abytes[i] ^ bbytes[i];
+        if secret.is_canonical() {
+            debug!("Used {} shares to reconstruct {:?}", shares.len(), secret);
+            return Ok(secret);
+        } else {
+            debug!("Value from XOR isn't within the group! {:?}", secret);
+            return Err(String::from("The reconstructed secret is outside the group"));
+        }
+
     }
-    Scalar::from_bits(the_bytes)
 }
 
 /// Given a list of scalars, XOR them all together.  We split out the `first` separately for efficiency's sake;
 /// there are use cases where the initial value you want to XOR with isn't in your Vector, so you don't need to
 /// push it.
+///
+/// The resulting value is **not** guaranteed to be modulo group order.  If this is important for your particular use
+/// case, you'll need to do those checks after calling this function.
 /// 
-/// TODO WARNING: the result isn't guaranteed to be modulo group order.  Is that going to be a problem?
 /// TODO is there a special way we need to write this function, to achieve some sort of SIMD benefit?
-pub fn xor_many_scalars(first: &Scalar, others: &[Scalar]) -> Result<Scalar, String> {
+fn xor_many_scalars<'a, T>(first: &Scalar, others: T) -> Scalar
+where
+    T: Iterator<Item=&'a Scalar>,
+{
     let mut the_bytes = first.clone().to_bytes();
-    for scalar in others.iter() {
+    for scalar in others {
         let scal_bytes = scalar.to_bytes();
         for i in 0..the_bytes.len() {
             the_bytes[i] ^= scal_bytes[i];
         }
     }
 
-    return Ok(Scalar::from_bits(the_bytes));
+    Scalar::from_bits(the_bytes)
 }
 
-/// See xor_many_scalars()
-pub fn xor_many_more_scalars(first: &Scalar, others: &Vec<Scalar>, still_others: &Vec<Scalar>) -> Result<Scalar, String> {
-    let mut the_bytes = first.clone().to_bytes();
-    for scalar in others.iter() {
-        let scal_bytes = scalar.to_bytes();
-        for i in 0..the_bytes.len() {
-            the_bytes[i] ^= scal_bytes[i];
-        }
-    }
-    for scalar in still_others.iter() {
-        let scal_bytes = scalar.to_bytes();
-        for i in 0..the_bytes.len() {
-            the_bytes[i] ^= scal_bytes[i];
-        }
-    }
-
-    return Ok(Scalar::from_bits(the_bytes));
-}
 
 #[allow(unused_imports)]
 mod tests {
     use super::*;
     use crate::toolbox::secrets::SecretSharing;
-
-    #[test]
-    fn xor_easy() {
-        let res1 = xor_scalars(&Scalar::zero(), &Scalar::zero());
-        assert_eq!(Scalar::zero(), res1);
-
-        let res2 = xor_scalars(&Scalar::zero(), &Scalar::one());
-        assert_eq!(Scalar::one(), res2);
-    }
-
-    #[test]
-    fn xor_medium() {
-        let a = Scalar::from(8675309u32);
-        let b = Scalar::from(5551212u32);
-        let c = Scalar::from(13691777u32);
-        assert_eq!(c, xor_scalars(&a, &b));
-    }
+    use curve25519_dalek::constants::BASEPOINT_ORDER;
 
     #[test]
     fn xor_many_easy() {
         let zeroes = vec![Scalar::zero(); 5];
-        let res1 = xor_many_scalars(&Scalar::zero(), &zeroes);
-        assert!(res1.is_ok());
-        assert_eq!(Scalar::zero(), res1.unwrap());
+        let res1 = xor_many_scalars(&Scalar::zero(), zeroes.iter());
+        assert_eq!(Scalar::zero(), res1);
 
-        let res2 = xor_many_scalars(&Scalar::one(), &zeroes);
-        assert!(res2.is_ok());
-        assert_eq!(Scalar::one(), res2.unwrap());
+        let res2 = xor_many_scalars(&Scalar::one(), zeroes.iter());
+        assert_eq!(Scalar::one(), res2);
     }
 
     #[test]
     fn xor_many_medium() {
         let scalars = vec![Scalar::from(8675309u32), Scalar::from(5551212u32), Scalar::from(4561414u32)];
-        let res1 = xor_many_scalars(&Scalar::zero(), &scalars);
-        assert!(res1.is_ok());
-        assert_eq!(Scalar::from(9793927u32), res1.unwrap());
+        let res1 = xor_many_scalars(&Scalar::zero(), scalars.iter());
+        assert_eq!(Scalar::from(9793927u32), res1);
 
-        let res2 = xor_many_scalars(&Scalar::from(9743901u32), &scalars);
-        assert!(res2.is_ok());
-        assert_eq!(Scalar::from(122778u32), res2.unwrap());
+        let res2 = xor_many_scalars(&Scalar::from(9743901u32), scalars.iter());
+        assert_eq!(Scalar::from(122778u32), res2);
     }
 
     #[test]
@@ -267,5 +225,20 @@ mod tests {
             },
             Err(e) => assert!(false, format!("Unable to complete: {}", e)),
         }
+    }
+
+    #[test]
+    fn xor_reconstruct_out_of_group() {
+        // 0x10 = 0000 1010             largest byte of \ell
+        // 0x5  = 0000 0101
+        //  XOR = 0000 1111
+
+        let share1 = Scalar::from_canonical_bytes([12, 227, 105, 171, 173, 162, 96, 141, 241, 244, 32, 246, 255, 9, 210, 32, 110, 245, 179, 133, 8, 34, 83, 32, 220, 162, 102, 9, 189, 38, 231, 5]).unwrap();
+        let share2 = BASEPOINT_ORDER;
+        let share3 = Scalar::from(74u8);
+
+        let mut xor = Xor::new_without_rng();
+        let shares = vec![share1, share2, share3];
+        assert!(xor.reconstruct(&shares).is_err(), "Shouldn't have been able to reconstruct!");
     }
 }

--- a/src/toolbox/xor.rs
+++ b/src/toolbox/xor.rs
@@ -2,6 +2,7 @@ use curve25519_dalek::scalar::Scalar;
 use rand::{CryptoRng, RngCore};
 use rand::prelude::ThreadRng;
 use crate::toolbox::secrets;
+use crate::toolbox::util::random_scalar;
 use log::{trace, debug, info};
 
 /// A SecretSharing implementation that is based on the all-shares XOR method.  In particular, you must have every outstanding share
@@ -30,10 +31,10 @@ impl<R> secrets::SecretSharing for Xor<R> where R: RngCore + CryptoRng {
     fn share(&mut self, secret: &Scalar, nr_of_shares: usize) -> Result<Vec<Scalar>, String> {
         info!("Sharing {} pieces of {:?}", nr_of_shares, secret);
         let mut shares: Vec<Scalar> = Vec::new();
-        
+
         // generate n - 1 random shares; the zero-th share is the secret
         for _ in 1..nr_of_shares {
-            shares.push(Scalar::random(&mut self.rng));
+            shares.push(random_scalar(&mut self.rng));
         }
 
         // calculate the final share as a function of the random shares and the secret
@@ -56,7 +57,7 @@ impl<R> secrets::SecretSharing for Xor<R> where R: RngCore + CryptoRng {
             } else {
                 if empties != 0 {     // the "zero-th" empty will be the one we have to XOR-calculate
                     trace!("Pushing a random Scalar to extra empty");
-                    new_shares.push(Scalar::random(&mut self.rng));
+                    new_shares.push(random_scalar(&mut self.rng));
                 }
                 empties += 1;
             }

--- a/src/toolbox/xor.rs
+++ b/src/toolbox/xor.rs
@@ -1,0 +1,248 @@
+use curve25519_dalek::scalar::Scalar;
+use rand::{CryptoRng, RngCore};
+use rand::prelude::ThreadRng;
+use crate::toolbox::secrets;
+use log::{debug, info};
+
+/// A SecretSharing implementation that is based on the all-shares XOR method.  In particular, you must have every outstanding share
+/// of a secret in order to reconstruct that secret.  Because it is the simplest method, it has no interesting parameters.
+pub struct Xor<R: CryptoRng + RngCore> {
+    rng: R,
+}
+
+impl<R> Xor<R> where R: RngCore + CryptoRng {
+    /// Create a new Xor object with the provided RNG implementation.
+    pub fn new(rng: R) -> Self {
+        Xor {
+            rng
+        }
+    }
+}
+
+impl Xor<ThreadRng> {
+    /// Create a new Xor object with a default RNG.
+    pub fn new_without_rng() -> Self {
+        Xor { rng: rand::thread_rng() }
+    }
+}
+
+impl<R> secrets::SecretSharing for Xor<R> where R: RngCore + CryptoRng {
+    fn share(&mut self, secret: &Scalar, nr_of_shares: usize) -> Result<Vec<Option<Scalar>>, String> {
+        info!("Sharing {} pieces of {:?}", nr_of_shares, secret);
+        let mut shares: Vec<Scalar> = Vec::new();
+        
+        // generate n - 1 random shares; the zero-th share is the secret
+        for _ in 1..nr_of_shares {
+            shares.push(Scalar::random(&mut self.rng));
+        }
+
+        // calculate the final share as a function of the random shares and the secret
+        match xor_many_scalars(secret, &shares) {
+            Ok(val) => shares.push(val),
+            Err(e) => return Err(e),
+        }
+
+        return Ok(shares.iter().map(|s| Some(*s)).collect::<Vec<Option<Scalar>>>());
+    }
+
+    /// For Xor, sparse_shares should include a None value for each share you want us to generate
+    fn complete(&mut self, secret: &Scalar, sparse_shares: &Vec<Option<Scalar>>) -> Result<Vec<Option<Scalar>>, String> {
+        let mut empties = 0;
+        let mut shares = Vec::new();
+        for share in sparse_shares.iter() {
+            if share.is_some() {
+                shares.push(share.unwrap());
+            } else {
+                empties += 1;
+            }
+        }
+
+        if empties < 1 {
+            return Err(String::from("No empty shares in which to complete!"));
+        }
+
+        info!("Completing {} empties with {} known and secret = {:?}", empties, shares.len(), secret);
+
+        // the "zero-th" empty will be the one we have to XOR-calculate
+        for _ in 1..empties {
+            shares.push(Scalar::random(&mut self.rng));
+        }
+        match xor_many_scalars(secret, &shares) {
+            Ok(val) => shares.push(val),
+            Err(e) => return Err(e),
+        }
+
+        return Ok(shares.iter().map(|s| Some(*s)).collect::<Vec<Option<Scalar>>>());
+    }
+
+    fn reconstruct(&mut self, shares: &Vec<Option<Scalar>>) -> Result<Scalar, String> {
+        if shares.len() < 1 {
+            return Err(String::from("No shares provided, impossible to reconstruct!"));
+        }
+
+        info!("Reconstructing from {} shares", shares.len());
+
+        // this will panic if any of the shares are None...
+        let my_shares = shares.iter().map(|s| s.unwrap()).collect::<Vec<Scalar>>();
+        let secret = xor_many_scalars(&my_shares[0], &my_shares[1..].to_vec());
+        
+        debug!("Reconstructed {:?}", secret);
+        return secret;
+    }
+}
+
+/// Given two Scalar values, return the XOR of their constituent byte arrays
+pub fn xor_scalars(a: &Scalar, b: &Scalar) -> Scalar {
+    let mut the_bytes = [0 as u8; 32];
+    let abytes = a.to_bytes();
+    let bbytes = b.to_bytes();
+    for i in 0..the_bytes.len() {
+        the_bytes[i] = abytes[i] ^ bbytes[i];
+    }
+    Scalar::from_bits(the_bytes)
+}
+
+/// Given a list of scalars, XOR them all together.  We split out the `first` separately for efficiency's sake;
+/// there are use cases where the initial value you want to XOR with isn't in your Vector, so you don't need to
+/// push it.
+/// 
+/// TODO WARNING: the result isn't guaranteed to be modulo group order.  Is that going to be a problem?
+pub fn xor_many_scalars(first: &Scalar, others: &Vec<Scalar>) -> Result<Scalar, String> {
+    if others.len() < 1 {
+        return Err(String::from("Vector was empty, impossible to XOR anything"));
+    }
+    // each Scalar is 32 bytes
+    let mut the_bytes = first.clone().to_bytes();
+    for scalar in others.iter() {
+        let scal_bytes = scalar.to_bytes();
+        for i in 0..the_bytes.len() {
+            the_bytes[i] ^= scal_bytes[i];
+        }
+    }
+
+    return Ok(Scalar::from_bits(the_bytes));
+}
+
+#[allow(unused_imports)]
+mod tests {
+    use super::*;
+    use crate::toolbox::secrets::SecretSharing;
+
+    #[test]
+    fn xor_easy() {
+        let res1 = xor_scalars(&Scalar::zero(), &Scalar::zero());
+        assert_eq!(Scalar::zero(), res1);
+
+        let res2 = xor_scalars(&Scalar::zero(), &Scalar::one());
+        assert_eq!(Scalar::one(), res2);
+    }
+
+    #[test]
+    fn xor_medium() {
+        let a = Scalar::from(8675309u32);
+        let b = Scalar::from(5551212u32);
+        let c = Scalar::from(13691777u32);
+        assert_eq!(c, xor_scalars(&a, &b));
+    }
+
+    #[test]
+    fn xor_many_easy() {
+        let zeroes = vec![Scalar::zero(); 5];
+        let res1 = xor_many_scalars(&Scalar::zero(), &zeroes);
+        assert!(res1.is_ok());
+        assert_eq!(Scalar::zero(), res1.unwrap());
+
+        let res2 = xor_many_scalars(&Scalar::one(), &zeroes);
+        assert!(res2.is_ok());
+        assert_eq!(Scalar::one(), res2.unwrap());
+    }
+
+    #[test]
+    fn xor_many_medium() {
+        let scalars = vec![Scalar::from(8675309u32), Scalar::from(5551212u32), Scalar::from(4561414u32)];
+        let res1 = xor_many_scalars(&Scalar::zero(), &scalars);
+        assert!(res1.is_ok());
+        assert_eq!(Scalar::from(9793927u32), res1.unwrap());
+
+        let res2 = xor_many_scalars(&Scalar::from(9743901u32), &scalars);
+        assert!(res2.is_ok());
+        assert_eq!(Scalar::from(122778u32), res2.unwrap());
+    }
+
+    #[test]
+    fn xor_share() {
+        let mut xor = Xor::new_without_rng();
+        let shares = xor.share(&Scalar::one(), 3);
+        assert!(shares.is_ok());
+        let new_shares = shares.unwrap().clone();
+        info!("Shares: {:?}", new_shares);
+        match xor.reconstruct(&new_shares) {
+            Ok(val) => assert_eq!(Scalar::one(), val),
+            Err(e) => assert!(false, format!("Error reconstructing secret: {}", e)),
+        }
+    }
+
+    #[test]
+    fn xor_reconstruct() {
+        let mut xor = Xor::new_without_rng();
+        let shares = vec![Some(Scalar::from(8675309u32)), Some(Scalar::from(5551212u32)), Some(Scalar::from(4561414u32))];
+        match xor.reconstruct(&shares) {
+            Ok(val) => assert_eq!(Scalar::from(9793927u32), val),
+            Err(e) => assert!(false, format!("Error reconstructing secret: {}", e)),
+        }
+    }
+
+    #[test]
+    fn xor_complete_easy() {
+        let mut xor = Xor::new_without_rng();
+        let sparse_shares = vec![Some(Scalar::from(123456789u32)), None];
+        match xor.complete(&Scalar::one(), &sparse_shares) {
+            Ok(shares) => {
+                assert_eq!(Scalar::from(123456789u32), shares[0].unwrap());
+                assert_eq!(Scalar::from(123456788u32), shares[1].unwrap());
+            },
+            Err(e) => assert!(false, format!("Error completing shares: {}", e))
+        }
+    }
+
+    #[test]
+    fn xor_complete_medium() {
+        let mut xor = Xor::new_without_rng();
+        let sparse_shares = vec![Some(Scalar::from(8675309u32)), Some(Scalar::from(5551212u32)), Some(Scalar::from(4561414u32)), None];
+        match xor.complete(&Scalar::from(122778u32), &sparse_shares) {
+            Ok(shares) => {
+                assert_eq!(Scalar::from(8675309u32), shares[0].unwrap());
+                assert_eq!(Scalar::from(5551212u32), shares[1].unwrap());
+                assert_eq!(Scalar::from(4561414u32), shares[2].unwrap());
+                assert_eq!(Scalar::from(9743901u32), shares[3].unwrap());
+            },
+            Err(e) => assert!(false, format!("Error completing shares: {}", e)),
+        }
+    }
+
+    #[test]
+    fn xor_complete_hard() {
+        let mut xor = Xor::new_without_rng();
+        let sparse_shares = vec![None, None, None, None, None, Some(Scalar::from(711117u32)), None, None, None, None];
+        match xor.complete(&Scalar::one(), &sparse_shares) {
+            Ok(shares) => {
+                assert_eq!(sparse_shares.len(), shares.len());
+                let mut found = false;
+                for s in shares.iter() {
+                    // make sure they're all filled in
+                    assert_ne!(None, *s);
+
+                    // make sure our one original share is in there somewhere
+                    if sparse_shares[5].unwrap() == s.unwrap() {
+                        found = true;
+                    }
+                }
+                assert!(found, "Didn't find original share in the completed list");
+                let val = xor.reconstruct(&shares);
+                assert!(val.is_ok());
+                assert_eq!(Scalar::one(), val.unwrap());
+            },
+            Err(e) => assert!(false, format!("Unable to complete: {}", e)),
+        }
+    }
+}

--- a/tests/and_clauses.rs
+++ b/tests/and_clauses.rs
@@ -6,6 +6,9 @@ extern crate curve25519_dalek;
 use curve25519_dalek::constants as dalek_constants;
 use curve25519_dalek::scalar::Scalar;
 
+use env_logger;
+use zkp::errors::ProofError;
+
 #[macro_use]
 extern crate zkp;
 pub use zkp::Transcript;
@@ -13,8 +16,13 @@ pub use zkp::Transcript;
 define_proof! {basic_and_clause, "basic_and_clause", (x,y), (A, B, G), () : A = (G ^ x) && B = (G ^ y)}
 define_proof! {complex_and_clause, "complex_and_clause", (x, y, z, a), (A, B, C, D, G), (): A = (G^x) && B = (G^y) && C = (G^z) && D = (G^a)}
 
+fn init() {
+    let _ = env_logger::builder().is_test(true).try_init();
+}
+
 #[test]
 fn and_test_basic() {
+    init();
     // Prover's scope
     let (proof, points) = {
         let x = Scalar::from(89327492234u64).invert();
@@ -41,20 +49,20 @@ fn and_test_basic() {
 
     // Verifier logic
     let mut transcript = Transcript::new(b"And Clause Test");
-    assert!(basic_and_clause::verify_compact(
+    let ver = basic_and_clause::verify_compact(
         &parsed_proof,
         &mut transcript,
         basic_and_clause::VerifyAssignments {
             A: &points.A,
             B: &points.B,
             G: &dalek_constants::RISTRETTO_BASEPOINT_COMPRESSED,
-        },
-    )
-    .is_ok());
+        });
+    assert!(ver.is_ok(), format!("Couldn't verify: {}", ver.unwrap_err()));
 }
 
 #[test]
 fn and_test_adv_wrong() {
+    init();
     // Prover's scope
     let (proof, points) = {
         let x = Scalar::from(89327492234u64).invert();
@@ -81,7 +89,7 @@ fn and_test_adv_wrong() {
 
     // Verifier logic
     let mut transcript = Transcript::new(b"And Clause Test");
-    assert!(basic_and_clause::verify_compact(
+    let ver = basic_and_clause::verify_compact(
         &parsed_proof,
         &mut transcript,
         basic_and_clause::VerifyAssignments {
@@ -89,12 +97,15 @@ fn and_test_adv_wrong() {
             B: &points.B,
             G: &dalek_constants::RISTRETTO_BASEPOINT_COMPRESSED,
         },
-    )
-    .is_err());
+    );
+    assert!(ver.is_err());
+    assert_eq!(ver.unwrap_err(), ProofError::VerificationFailure);
+
 }
 
 #[test]
 fn and_test_complex() {
+    init();
     // Prover's scope
     let res = {
         let x = Scalar::from(89327492234u64).invert();
@@ -142,10 +153,7 @@ fn and_test_complex() {
                     G: &dalek_constants::RISTRETTO_BASEPOINT_COMPRESSED,
                 },
             );
-            match ver {
-                Err(e) => assert!(false, format!("Error verifying proof: {}", e)),
-                Ok(_) => assert!(true),
-            }
+            assert!(ver.is_ok(), format!("Error verifying proof: {}", ver.unwrap_err()));
         },
     }
 }
@@ -153,6 +161,7 @@ fn and_test_complex() {
 
 #[test]
 fn and_test_insufficient_keys() {
+    init();
     // Prover's scope
     let res = {
         let x = Scalar::from(89327492234u64).invert();

--- a/tests/or_clauses.rs
+++ b/tests/or_clauses.rs
@@ -203,7 +203,6 @@ fn or_test_basic() {
     // Prover's scope
     let (proof, points) = {
         let x = Scalar::from(89327492234u64).invert();
-        let y = None;
         let A = &x * &dalek_constants::RISTRETTO_BASEPOINT_TABLE;
         let B = &Scalar::from(7u32) * &dalek_constants::RISTRETTO_BASEPOINT_TABLE;
 
@@ -212,7 +211,7 @@ fn or_test_basic() {
             &mut transcript,
             basic_or_clause::ProveAssignments {
                 x: &Some(x),
-                y: &y,
+                y: &None,
                 A: &A,
                 B: &B,
                 G: &dalek_constants::RISTRETTO_BASEPOINT_POINT,
@@ -226,7 +225,7 @@ fn or_test_basic() {
 
     // Verifier logic
     let mut transcript = Transcript::new(b"Or Clause Test");
-    assert!(basic_or_clause::verify_compact(
+    let ver = basic_or_clause::verify_compact(
         &parsed_proof,
         &mut transcript,
         basic_or_clause::VerifyAssignments {
@@ -234,8 +233,8 @@ fn or_test_basic() {
             B: &points.B,
             G: &dalek_constants::RISTRETTO_BASEPOINT_COMPRESSED,
         },
-    )
-    .is_ok());
+    );
+    assert!(ver.is_ok(), format!("Couldn't verify: {}", ver.unwrap_err()));
 }
 
 #[test]

--- a/tests/or_clauses.rs
+++ b/tests/or_clauses.rs
@@ -333,7 +333,7 @@ fn or_test_wrong_keys() {
         let A = &x * &dalek_constants::RISTRETTO_BASEPOINT_TABLE;
         let B = &y * &dalek_constants::RISTRETTO_BASEPOINT_TABLE;
         let C = &Scalar::from(3u32) * &dalek_constants::RISTRETTO_BASEPOINT_TABLE;
-        let D = &Scalar::from(3u32) * &dalek_constants::RISTRETTO_BASEPOINT_TABLE;
+        let D = &Scalar::from(4u32) * &dalek_constants::RISTRETTO_BASEPOINT_TABLE;
 
         let mut transcript = Transcript::new(b"Or Clause Test");
         complex_or_clause::prove_compact(
@@ -375,3 +375,5 @@ fn or_test_wrong_keys() {
         },
     }
 }
+
+// TODO need to test what the verifier would do if we had a statement like complex_or but only had keys for A and C


### PR DESCRIPTION
This PR adds support for multiple secret-sharing algorithms, including Shamir and XOR at first.  There is no support for dynamically deciding which algorithm to use, but we can add that later.